### PR TITLE
Add iam:AttachRolePolicy to aws_iam_policy.account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,7 @@ resource "aws_iam_policy" "account" {
         {
             "Effect": "Allow",
             "Action": [
+                "iam:AttachRolePolicy",
                 "iam:CreateRole",
                 "iam:GetRole",
                 "iam:ListAttachedRolePolicies",


### PR DESCRIPTION
# Summary
This permission is required to manage account assignments in the SSO instance account
